### PR TITLE
Added Webstorm & Mac files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist
 # Dependencies
 node_modules
 typings
+
+# Webstorm/Mac files
+.idea
+.DS_Store


### PR DESCRIPTION
I'm always annoyed by the hidden files Webstorm and OSX creates. I'd like to have them in the .gitignore by default.

I don't mind using my own fork it you think it's too specific. ^^ 